### PR TITLE
fix: unable to navigate by prefetch on A/B test target paths

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@geist-ui/react": "^2.2.0",
     "next": "12.0.7",
-    "next-with-split": "^4.2.2-beta.1",
+    "next-with-split": "4.2.1-beta.2",
     "react": "17.0.2",
     "react-dom": "17.0.2"
   },

--- a/example/package.json
+++ b/example/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@geist-ui/react": "^2.2.0",
     "next": "12.0.7",
-    "next-with-split": "^4.2.1-beta.1",
+    "next-with-split": "^4.2.2-beta.1",
     "react": "17.0.2",
     "react-dom": "17.0.2"
   },

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -1095,7 +1095,7 @@ nanoid@^3.1.23:
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.30.tgz#63f93cc548d2a113dc5dfbc63bfa09e2b9b64362"
   integrity sha512-zJpuPDwOv8D2zq2WRoMe1HsfZthVewpel9CAvTfc/2mBD1uUT/agc5f7GHGWXlYkFvi1mVxe4IjvP2HNrop7nQ==
 
-next-with-split@^4.2.2-beta.1:
+next-with-split@4.2.1-beta.2:
   version "4.2.1-beta.2"
   resolved "https://registry.yarnpkg.com/next-with-split/-/next-with-split-4.2.1-beta.2.tgz#75476bbae257d2dcac31e8cf61578819e30cd8f3"
   integrity sha512-pyXRW+8eif408r8RbE+qx37hexeFk3RtEaIsyTHxXlPviC6e87CnQdllxB/tjGo27hLpoTzvYh+Oy8/CTokp2w==

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -1095,10 +1095,10 @@ nanoid@^3.1.23:
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.30.tgz#63f93cc548d2a113dc5dfbc63bfa09e2b9b64362"
   integrity sha512-zJpuPDwOv8D2zq2WRoMe1HsfZthVewpel9CAvTfc/2mBD1uUT/agc5f7GHGWXlYkFvi1mVxe4IjvP2HNrop7nQ==
 
-next-with-split@^4.2.1-beta.1:
-  version "4.2.1-beta.1"
-  resolved "https://registry.yarnpkg.com/next-with-split/-/next-with-split-4.2.1-beta.1.tgz#4250f971507ab4222d76f8f269812a22ead1ce56"
-  integrity sha512-9k23Y7cr+IrPGVFeiQh775y4KC7zT6/aKi9apKsK2LF70azwtgssm7qH0y9fWKNeLX4lkJw0nHxssvH5NSHQ5g==
+next-with-split@^4.2.2-beta.1:
+  version "4.2.1-beta.2"
+  resolved "https://registry.yarnpkg.com/next-with-split/-/next-with-split-4.2.1-beta.2.tgz#75476bbae257d2dcac31e8cf61578819e30cd8f3"
+  integrity sha512-pyXRW+8eif408r8RbE+qx37hexeFk3RtEaIsyTHxXlPviC6e87CnQdllxB/tjGo27hLpoTzvYh+Oy8/CTokp2w==
 
 next@12.0.7:
   version "12.0.7"


### PR DESCRIPTION

### From outside the target path (top) to inside the target path (/foo/bar).
Assigned to the Challenger in advance.
![スクリーンショット 2021-12-21 午後1 49 24](https://user-images.githubusercontent.com/6711766/146873621-f9b5601d-58ef-46df-aa41-4181ff46627e.png)
**A header with x-middleware-reflesh is returned for prefligt access, and finally the document is fully loaded.**

---
### From within the target path(/foo/bar) to within the target path(/foo/baz)
Assigned to the Challenger in advance.
![スクリーンショット 2021-12-21 午後1 50 21](https://user-images.githubusercontent.com/6711766/146874074-2287c4bf-b16f-4da9-8d96-4a1adfaee80d.png)
Navigation by prefetch is occurring.
